### PR TITLE
Update to version 7.61.0.Final

### DIFF
--- a/jbpm-system-test/jbpm-clustered-ejb-timers-test/pom.xml
+++ b/jbpm-system-test/jbpm-clustered-ejb-timers-test/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-system-test</artifactId>
-    <version>7.58.0.Final</version>
+    <version>7.61.0.Final</version>
   </parent>
 
   <artifactId>jbpm-clustered-ejb-timers-test</artifactId>
@@ -190,7 +190,7 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <org.kie.samples.image>jboss/kie-server-showcase:${version.org.kie}</org.kie.samples.image>
+        <org.kie.samples.image>quay.io/kiegroup/kie-server-showcase:${version.org.kie}</org.kie.samples.image>
         <org.kie.samples.script>start_kie-server.sh</org.kie.samples.script>
         <org.kie.samples.server>kie-server</org.kie.samples.server>
       </properties>

--- a/jbpm-system-test/jbpm-clustered-ejb-timers-test/src/test/resources/etc/jbpm-custom-template.cli
+++ b/jbpm-system-test/jbpm-clustered-ejb-timers-test/src/test/resources/etc/jbpm-custom-template.cli
@@ -42,9 +42,8 @@ xa-data-source add --name=rhpamXADS --jndi-name=java:/rhpamXADS --driver-name=po
 /system-property=org.kie.server.persistence.dialect:add(value=org.hibernate.dialect.PostgreSQLDialect)
 
 #EJB Timer configuration
-/subsystem=ejb3/service=timer-service/file-data-store=default-file-store:remove
 /subsystem=ejb3/service=timer-service/database-data-store=ejb_timer_ds:add(datasource-jndi-name="java:/rhpamXADS",database="postgresql",partition=%partition_name%,refresh-interval="1000")
 /subsystem=ejb3/service=timer-service:write-attribute(name="default-data-store", value="ejb_timer_ds")
-
+/subsystem=ejb3/service=timer-service/file-data-store=default-file-store:remove
 
 stop-embedded-server

--- a/jbpm-system-test/jbpm-tx-ejb-timers-test/pom.xml
+++ b/jbpm-system-test/jbpm-tx-ejb-timers-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm-system-test</artifactId>
-    <version>7.58.0.Final</version>
+    <version>7.61.0.Final</version>
   </parent>
   
   <artifactId>jbpm-tx-ejb-timers-test</artifactId>
@@ -187,7 +187,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <org.kie.samples.image>jboss/kie-server-showcase:${version.org.kie}</org.kie.samples.image>
+            <org.kie.samples.image>quay.io/kiegroup/kie-server-showcase:${version.org.kie}</org.kie.samples.image>
             <org.kie.samples.script>start_kie-server.sh</org.kie.samples.script>
             <org.kie.samples.server>kie-server</org.kie.samples.server>
             <org.jbpm.ejb.timer.local.cache>false</org.jbpm.ejb.timer.local.cache>

--- a/jbpm-system-test/jbpm-tx-ejb-timers-test/src/test/java/org/kie/samples/integration/testcontainers/KieServerContainer.java
+++ b/jbpm-system-test/jbpm-tx-ejb-timers-test/src/test/java/org/kie/samples/integration/testcontainers/KieServerContainer.java
@@ -45,6 +45,7 @@ public class KieServerContainer extends GenericContainer<KieServerContainer>{
     
       withEnv("START_SCRIPT", args.get("START_SCRIPT"));
       withEnv("JAVA_OPTS", "-Xms256m -Xmx2048m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8 "+
+                           "-Dorg.kie.jbpm.timer.retry.limit=1 -Dorg.kie.jbpm.timer.retry.interval=500 "+
                            "-Dorg.jbpm.ejb.timer.local.cache="+args.get("cache")+" -Dorg.jbpm.ejb.timer.tx="+args.get("timer-tx"));
       withNetwork(network);
       withNetworkAliases(ALIAS);

--- a/jbpm-system-test/jbpm-tx-ejb-timers-test/src/test/resources/etc/jbpm-custom-node1.cli
+++ b/jbpm-system-test/jbpm-tx-ejb-timers-test/src/test/resources/etc/jbpm-custom-node1.cli
@@ -42,9 +42,8 @@ xa-data-source add --name=rhpamXADS --jndi-name=java:/rhpamXADS --driver-name=po
 /system-property=org.kie.server.persistence.dialect:add(value=org.hibernate.dialect.PostgreSQLDialect)
 
 #EJB Timer configuration
-/subsystem=ejb3/service=timer-service/file-data-store=default-file-store:remove
 /subsystem=ejb3/service=timer-service/database-data-store=ejb_timer_ds:add(datasource-jndi-name="java:/rhpamXADS",database="postgresql",partition="ejb_timer_node1_part",refresh-interval="10000")
 /subsystem=ejb3/service=timer-service:write-attribute(name="default-data-store", value="ejb_timer_ds")
-
+/subsystem=ejb3/service=timer-service/file-data-store=default-file-store:remove
 
 stop-embedded-server

--- a/jbpm-system-test/pom.xml
+++ b/jbpm-system-test/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
     <!-- it must be a final one as the image must be on dockerhub -->
-    <version>7.58.0.Final</version>
+    <version>7.61.0.Final</version>
   </parent>
   
   <groupId>org.jbpm</groupId>


### PR DESCRIPTION
Update to version 7.61.0.Final which downloads the kie-server images from quay.io.

Also pull down the default-file-store:remove order in jboss-cli script to avoid failure.

For tx-ejb-timers test, as now the PLATFORM strategy has disappeared with https://github.com/kiegroup/jbpm/pull/2001, retries are attempted (so they are set up to just one retry, after 500 ms, to keep the same sleeps and timers in the bpmn and test). 